### PR TITLE
Support ARC-25

### DIFF
--- a/packages/helpers/qrcode-modal/src/index.ts
+++ b/packages/helpers/qrcode-modal/src/index.ts
@@ -8,13 +8,29 @@ const isNode = () =>
   typeof process.versions !== "undefined" &&
   typeof process.versions.node !== "undefined";
 
-function open(uri: string, cb: any, qrcodeModalOptions?: IQRCodeModalOptions) {
+export type AlgorandQRCodeModalOptions = IQRCodeModalOptions & {
+  addAlgorandMarkerToUri?: boolean;
+};
+
+const ALGORAND_QUERY_PARAM_NAME = "algorand";
+
+function open(uri: string, cb: any, qrcodeModalOptions?: AlgorandQRCodeModalOptions) {
+  const { addAlgorandMarkerToUri, ...vanillaOptions } = qrcodeModalOptions || {};
+
+  if (addAlgorandMarkerToUri == null || addAlgorandMarkerToUri) {
+    const urlObject = new URL(uri);
+    if (!urlObject.searchParams.has(ALGORAND_QUERY_PARAM_NAME)) {
+      urlObject.searchParams.set(ALGORAND_QUERY_PARAM_NAME, "true");
+      uri = urlObject.toString();
+    }
+  }
+
   // eslint-disable-next-line no-console
   console.log(uri);
   if (isNode()) {
     nodeLib.open(uri);
   } else {
-    browserLib.open(uri, cb, qrcodeModalOptions);
+    browserLib.open(uri, cb, vanillaOptions);
   }
 }
 

--- a/packages/helpers/qrcode-modal/src/index.ts
+++ b/packages/helpers/qrcode-modal/src/index.ts
@@ -2,6 +2,7 @@ import { IQRCodeModalOptions } from "@walletconnect/types";
 
 import * as nodeLib from "./node";
 import * as browserLib from "./browser";
+import { transformUri } from "./transform";
 
 const isNode = () =>
   typeof process !== "undefined" &&
@@ -12,18 +13,10 @@ export type AlgorandQRCodeModalOptions = IQRCodeModalOptions & {
   addAlgorandMarkerToUri?: boolean;
 };
 
-const ALGORAND_QUERY_PARAM_NAME = "algorand";
-
 function open(uri: string, cb: any, qrcodeModalOptions?: AlgorandQRCodeModalOptions) {
   const { addAlgorandMarkerToUri, ...vanillaOptions } = qrcodeModalOptions || {};
 
-  if (addAlgorandMarkerToUri == null || addAlgorandMarkerToUri) {
-    const urlObject = new URL(uri);
-    if (!urlObject.searchParams.has(ALGORAND_QUERY_PARAM_NAME)) {
-      urlObject.searchParams.set(ALGORAND_QUERY_PARAM_NAME, "true");
-      uri = urlObject.toString();
-    }
-  }
+  uri = transformUri(uri, addAlgorandMarkerToUri);
 
   // eslint-disable-next-line no-console
   console.log(uri);

--- a/packages/helpers/qrcode-modal/src/transform.ts
+++ b/packages/helpers/qrcode-modal/src/transform.ts
@@ -1,0 +1,13 @@
+
+const ALGORAND_QUERY_PARAM_NAME = "algorand";
+
+export function transformUri(uri: string, addAlgorandMarkerToUri?: boolean): string {
+  if (addAlgorandMarkerToUri == null || addAlgorandMarkerToUri) {
+    const urlObject = new URL(uri);
+    if (!urlObject.searchParams.has(ALGORAND_QUERY_PARAM_NAME)) {
+      urlObject.searchParams.set(ALGORAND_QUERY_PARAM_NAME, "true");
+      return urlObject.toString();
+    }
+  }
+  return uri;
+}

--- a/packages/helpers/qrcode-modal/test/transform.spec.ts
+++ b/packages/helpers/qrcode-modal/test/transform.spec.ts
@@ -1,0 +1,53 @@
+import "mocha";
+import { expect } from "chai";
+
+import { transformUri } from "../src/transform";
+
+// NOTE: the values in this map are not the only acceptable transformation of the URI, since the
+// "algorand" marker can appear in any order with the other query params. Our implementation always
+// adds the parameter at the end, so this test is good enough to verify that.
+const cases: Map<string, string> = new Map([
+    [
+        // WC URI with no "algorand" marker
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655",
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655&algorand=true",
+    ],
+    [
+        // WC URI with an "algorand" marker already at the end
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655&algorand=true",
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655&algorand=true",
+    ],
+    [
+        // WC URI with an "algorand" marker already, not at the end
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&algorand=true&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655",
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?bridge=https%3A%2F%2F9.bridge.walletconnect.org&algorand=true&key=b0576e0880e17f8400bfff92d4caaf2158cccc0f493dcf455ba76d448c9b5655",
+    ],
+    [
+        // not a valid WC URI, since there are no query params, but let's make sure we still produce a valid URI
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1",
+        "wc:4015f93f-b88d-48fc-8bfe-8b063cc325b6@1?algorand=true",
+    ],
+]);
+
+describe("transformUri", () => {
+  it("adds marker by default", () => {
+    for (const [input, expected] of cases) {
+        const actual = transformUri(input);
+        expect(actual).to.equal(expected);
+    }
+  });
+
+  it("adds marker when enabled", () => {
+    for (const [input, expected] of cases) {
+        const actual = transformUri(input, true);
+        expect(actual).to.equal(expected);
+    }
+  });
+
+  it("does not add marker when disabled", () => {
+    for (const [input] of cases) {
+        const actual = transformUri(input, false);
+        expect(actual).to.equal(input);
+    }
+  });
+});


### PR DESCRIPTION
This PR causes the `algorand-walletconnect-qrcode-modal` package to add the `algorand=true` marker to WalletConnect URIs by default, as specified in https://github.com/algorandfoundation/ARCs/pull/96.

With this change, users of the library would not need to do anything special in order to take advantage of the benefits from the Algorand-specific URI marker.